### PR TITLE
Help GCC to optimize msb() to single instruction

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -291,7 +291,7 @@ inline Square lsb(Bitboard b) {
 
 inline Square msb(Bitboard b) {
   assert(b);
-  return Square(63 - __builtin_clzll(b));
+  return Square(63 ^ __builtin_clzll(b));
 }
 
 #elif defined(_WIN64) && defined(_MSC_VER)


### PR DESCRIPTION
GCC compiles builtin_clzll to “63 ^ BSR”. BSR is processor instruction "Bit Scan Reverse".
So old msb() function is basically 63 - 63 ^ BSR.
Unfortunately, GCC fails to simplify this expression.

Old function compiles to

    bsrq    %rdi, %rdi
    movl    $63, %eax
    xorq    $63, %rdi
    subl    %edi, %eax
    ret

New function compiles to

    bsrq    %rdi, %rax
    ret

BTW, Clang compiles both function to the same (optimal) code.

No functional change.