### PR TITLE
Pr/3

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -185,22 +185,22 @@ namespace {
   // which piece type attacks which one. Attacks on lesser pieces which are
   // pawn-defended are not considered.
   const Score ThreatByMinor[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 33), S(45, 43), S(46, 47), S(72, 107), S(48, 118)
+    S(0, 0), S(0, 31), S(39, 42), S(57, 44), S(68, 112), S(47, 120)
   };
 
   const Score ThreatByRook[PIECE_TYPE_NB] = {
-    S(0, 0), S(0, 25), S(40, 62), S(40, 59), S(0, 34), S(35, 48)
+    S(0, 0), S(0, 24), S(38, 71), S(38, 61), S(0, 38), S(36, 38)
   };
 
   // ThreatByKing[on one/on many] contains bonuses for king attacks on
   // pawns or pieces which are not pawn-defended.
-  const Score ThreatByKing[] = { S(3, 62), S(9, 138) };
+  const Score ThreatByKing[] = { S(3, 65), S(9, 145) };
 
   // Passed[mg/eg][Rank] contains midgame and endgame bonuses for passed pawns.
   // We don't use a Score because we process the two components independently.
   const Value Passed[][RANK_NB] = {
-    { V(0), V(5), V( 5), V(31), V(73), V(166), V(252) },
-    { V(0), V(7), V(14), V(38), V(73), V(166), V(252) }
+    { V(0), V(5), V( 5), V(32), V(70), V(172), V(217) },
+    { V(0), V(7), V(13), V(42), V(70), V(170), V(269) }
   };
 
   // PassedFile[File] contains a bonus according to the file of a passed pawn
@@ -210,7 +210,7 @@ namespace {
   };
 
   // Rank factor applied on some bonus for passed pawn on rank 4 or beyond
-  const int RankFactor[RANK_NB] = {0, 0, 0, 2, 6, 11, 16};
+  const int RankFactor[RANK_NB] = {0, 0, 0, 2, 7, 12, 19};
 
   // KingProtector[PieceType-2] contains a bonus according to distance from king
   const Score KingProtector[] = { S(-3, -5), S(-4, -3), S(-3, 0), S(-1, 1) };
@@ -224,13 +224,13 @@ namespace {
   const Score WeakQueen             = S( 50, 10);
   const Score CloseEnemies          = S(  7,  0);
   const Score PawnlessFlank         = S( 20, 80);
-  const Score ThreatBySafePawn      = S(192,175);
+  const Score ThreatBySafePawn      = S(175,168);
   const Score ThreatByRank          = S( 16,  3);
-  const Score Hanging               = S( 48, 27);
+  const Score Hanging               = S( 52, 30);
   const Score WeakUnopposedPawn     = S(  5, 25);
-  const Score ThreatByPawnPush      = S( 38, 22);
-  const Score ThreatByAttackOnQueen = S( 38, 22);
-  const Score HinderPassedPawn      = S(  7,  0);
+  const Score ThreatByPawnPush      = S( 47, 26);
+  const Score ThreatByAttackOnQueen = S( 42, 21);
+  const Score HinderPassedPawn      = S(  8,  1);
   const Score TrappedBishopA1H1     = S( 50, 50);
 
   #undef S
@@ -690,7 +690,7 @@ namespace {
 
                 // If there aren't any enemy attacks, assign a big bonus. Otherwise
                 // assign a smaller bonus if the block square isn't attacked.
-                int k = !unsafeSquares ? 18 : !(unsafeSquares & blockSq) ? 8 : 0;
+                int k = !unsafeSquares ? 20 : !(unsafeSquares & blockSq) ? 9 : 0;
 
                 // If the path to the queen is fully defended, assign a big bonus.
                 // Otherwise assign a smaller bonus if the block square is defended.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -923,7 +923,10 @@ std::string Eval::trace(const Position& pos) {
 
   std::memset(scores, 0, sizeof(scores));
 
-  Value v = Evaluation<TRACE>(pos).value() + Eval::Tempo;
+  Eval::Contempt = SCORE_ZERO;
+
+  Value v = Eval::Tempo + Evaluation<TRACE>(pos).value();
+
   v = pos.side_to_move() == WHITE ? v : -v; // White's point of view
 
   std::stringstream ss;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -221,17 +221,17 @@ Move MovePicker::next_move(bool skipQuiets) {
       /* fallthrough */
 
   case QUIET:
-      while (    cur < endMoves
-             && (!skipQuiets || cur->value >= VALUE_ZERO))
-      {
-          move = *cur++;
+      if (!skipQuiets)
+         while (cur < endMoves)
+         {
+             move = *cur++;
 
-          if (   move != ttMove
-              && move != killers[0]
-              && move != killers[1]
-              && move != countermove)
-              return move;
-      }
+             if (   move != ttMove
+                 && move != killers[0]
+                 && move != killers[1]
+                 && move != countermove)
+                 return move;
+         }
       ++stage;
       cur = moves; // Point to beginning of bad captures
       /* fallthrough */

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -46,14 +46,14 @@ namespace {
   // Weakness of our pawn shelter in front of the king by [isKingFile][distance from edge][rank].
   // RANK_1 = 0 is used for files where we have no pawns or our pawn is behind our king.
   const Value ShelterWeakness[][int(FILE_NB) / 2][RANK_NB] = {
-    { { V( 97), V(17), V( 9), V(44), V( 84), V( 87), V( 99) }, // Not On King file
-      { V(106), V( 6), V(33), V(86), V( 87), V(104), V(112) },
-      { V(101), V( 2), V(65), V(98), V( 58), V( 89), V(115) },
-      { V( 73), V( 7), V(54), V(73), V( 84), V( 83), V(111) } },
-    { { V(104), V(20), V( 6), V(27), V( 86), V( 93), V( 82) }, // On King file
-      { V(123), V( 9), V(34), V(96), V(112), V( 88), V( 75) },
-      { V(120), V(25), V(65), V(91), V( 66), V( 78), V(117) },
-      { V( 81), V( 2), V(47), V(63), V( 94), V( 93), V(104) } }
+    { { V( 98), V(20), V(11), V(42), V( 83), V( 84), V(101) }, // Not On King file
+      { V(103), V( 8), V(33), V(86), V( 87), V(105), V(113) },
+      { V(100), V( 2), V(65), V(95), V( 59), V( 89), V(115) },
+      { V( 72), V( 6), V(52), V(74), V( 83), V( 84), V(112) } },
+    { { V(105), V(19), V( 3), V(27), V( 85), V( 93), V( 84) }, // On King file
+      { V(121), V( 7), V(33), V(95), V(112), V( 86), V( 72) },
+      { V(121), V(26), V(65), V(90), V( 65), V( 76), V(117) },
+      { V( 79), V( 0), V(45), V(65), V( 94), V( 92), V(105) } }
   };
 
   // Danger of enemy pawns moving toward our king by [type][distance from edge][rank].


### PR DESCRIPTION
The 'eval' debugging command in Terminal did not initialize the Eval::Contempt
variable, leading to random output during debugging sessions (normal search
was unaffected by the bug).

Example of session where the two 'eval' commands should give the same output,
but did not:

./stockfish
position startpos
d
eval
go depth 20
d
eval

The bug is fixed by initializing Eval::Contempt to SCORE_ZERO in Eval::trace

No functional change.